### PR TITLE
Replace SharePoint team list with Azure Graph API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ build:
 test:
 	go test ./... -count=1
 
+integration_test:
+	go test ./pkg/azure/azure_test.go -tags=integration -v -count=1
+
 release:
 	go build -a -installsuffix cgo -o tobac -ldflags "-s $(LDFLAGS)"
 

--- a/go.mod
+++ b/go.mod
@@ -10,12 +10,11 @@ require (
 	github.com/prometheus/client_golang v0.9.2
 	github.com/sirupsen/logrus v1.2.0
 	github.com/spf13/pflag v1.0.3
-	github.com/stretchr/testify v1.2.2
+	github.com/stretchr/testify v1.4.0
 	golang.org/x/oauth2 v0.0.0-20181120190819-8f65e3013eba
 	golang.org/x/time v0.0.0-20181108054448-85acf8d2951c // indirect
 	google.golang.org/appengine v1.3.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v2 v2.2.1 // indirect
 	k8s.io/api v0.0.0-20181204000039-89a74a8d264d
 	k8s.io/apimachinery v0.0.0-20181127025237-2b1284ed4c93
 	k8s.io/client-go v10.0.0+incompatible

--- a/pkg/azure/azure.go
+++ b/pkg/azure/azure.go
@@ -3,12 +3,13 @@ package azure
 import (
 	"context"
 	"encoding/json"
-	log "github.com/sirupsen/logrus"
 	"fmt"
 	"net/http"
 	"net/url"
 	"os"
 	"time"
+
+	log "github.com/sirupsen/logrus"
 
 	"golang.org/x/oauth2/clientcredentials"
 	"golang.org/x/oauth2/microsoft"

--- a/pkg/azure/azure.go
+++ b/pkg/azure/azure.go
@@ -2,41 +2,27 @@ package azure
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 	"net/http"
-	"net/url"
 	"os"
 	"time"
 
 	log "github.com/sirupsen/logrus"
-
 	"golang.org/x/oauth2/clientcredentials"
 	"golang.org/x/oauth2/microsoft"
 )
 
 var (
-	clientID     = os.Getenv("AZURE_APP_ID")
-	clientSecret = os.Getenv("AZURE_PASSWORD")
-	tenantID     = os.Getenv("AZURE_TENANT")
+	clientID        = os.Getenv("AZURE_APP_ID")
+	clientSecret    = os.Getenv("AZURE_PASSWORD")
+	tenantID        = os.Getenv("AZURE_TENANT")
+	teamParentGroup = os.Getenv("AZURE_TEAM_PARENT_GROUP")
 )
 
-const sharepointQuery = "9f0d0ea1-0226-4aa9-9bf9-b6e75816fabf/sites/root/lists/nytt team/items?expand=fields"
-
-type sharePointList struct {
-	Value []sharePointListEntry `json:"value"`
-}
-
-type sharePointListEntry struct {
-	Fields Team `json:"fields"`
-}
-
-// Team struc used to deserialize fields from sharePointListEntry.
 type Team struct {
-	AzureUUID   string `json:"GruppeID"`
-	ID          string `json:"mailnick_x002f_tag"`
-	Title       string `json:"Title"`
-	Description string `json:"Beskrivelse"`
+	AzureUUID   string
+	ID          string
+	Title       string
+	Description string
 }
 
 // Valid returns true if the ID fields are non-empty.
@@ -55,46 +41,27 @@ func client(ctx context.Context) *http.Client {
 	return config.Client(ctx)
 }
 
-func get(ctx context.Context, path string, target interface{}) error {
-	getURL, err := url.Parse("https://graph.microsoft.com/v1.0/groups/" + path)
-	if err != nil {
-		return err
-	}
-
-	req := &http.Request{
-		Method: "GET",
-		URL:    getURL,
-	}
-
-	resp, err := client(ctx).Do(req)
-	if err != nil {
-		return err
-	}
-
-	err = json.NewDecoder(resp.Body).Decode(target)
-
-	return err
-}
-
 // Teams retrieves the canonical list of team groups from the Microsoft Graph API.
 func Teams(ctx context.Context) (map[string]Team, error) {
-	teams := make(map[string]Team)
+	graphAPI := NewGraphAPI(client(ctx))
 
-	list := &sharePointList{}
-	err := get(ctx, sharepointQuery, list)
+	teamGroups, err := graphAPI.GroupsInGroup(teamParentGroup)
 	if err != nil {
 		return nil, err
 	}
 
-	if len(list.Value) == 0 {
-		return nil, fmt.Errorf("list of teams is empty; possible unhandled error")
-	}
-
-	for _, v := range list.Value {
-		team := v.Fields
+	teams := make(map[string]Team)
+	for _, teamGroup := range teamGroups {
+		team := Team{
+			AzureUUID: teamGroup.ID,
+			Title:     teamGroup.DisplayName,
+			ID:        teamGroup.MailNickname,
+		}
 		if team.Valid() {
 			teams[team.ID] = team
 			log.Debugf("azure: add team '%s' with id '%s'", team.ID, team.AzureUUID)
+		} else {
+			log.Errorf("azure: invalid team '%s'", team.ID)
 		}
 	}
 

--- a/pkg/azure/azure.go
+++ b/pkg/azure/azure.go
@@ -12,10 +12,10 @@ import (
 )
 
 var (
-	clientID        = os.Getenv("AZURE_APP_ID")
-	clientSecret    = os.Getenv("AZURE_PASSWORD")
-	tenantID        = os.Getenv("AZURE_TENANT")
-	teamParentGroup = os.Getenv("AZURE_TEAM_PARENT_GROUP")
+	clientID                    = os.Getenv("AZURE_APP_ID")
+	clientSecret                = os.Getenv("AZURE_PASSWORD")
+	tenantID                    = os.Getenv("AZURE_TENANT")
+	teamMembershipApplicationID = os.Getenv("AZURE_TEAM_MEMBERSHIP_APP_ID")
 )
 
 type Team struct {
@@ -45,7 +45,7 @@ func client(ctx context.Context) *http.Client {
 func Teams(ctx context.Context) (map[string]Team, error) {
 	graphAPI := NewGraphAPI(client(ctx))
 
-	teamGroups, err := graphAPI.GroupsInGroup(teamParentGroup)
+	teamGroups, err := graphAPI.GroupsFromApplication(teamMembershipApplicationID)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/azure/azure.go
+++ b/pkg/azure/azure.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -55,13 +56,16 @@ func Teams(ctx context.Context) (map[string]Team, error) {
 		team := Team{
 			AzureUUID: teamGroup.ID,
 			Title:     teamGroup.DisplayName,
-			ID:        teamGroup.MailNickname,
+			ID:        strings.ToLower(teamGroup.MailNickname),
 		}
 		if team.Valid() {
 			teams[team.ID] = team
 			log.Debugf("azure: add team '%s' with id '%s'", team.ID, team.AzureUUID)
 		} else {
 			log.Errorf("azure: invalid team '%s'", team.ID)
+		}
+		if team.ID != teamGroup.MailNickname {
+			log.Warnf("azure: transposing real team name '%s' to lowercase '%s'", teamGroup.MailNickname, team.ID)
 		}
 	}
 

--- a/pkg/azure/azure_test.go
+++ b/pkg/azure/azure_test.go
@@ -3,9 +3,8 @@
 package azure_test
 
 import (
-	"fmt"
-	"github.com/stretchr/testify/assert"
 	"testing"
+	"time"
 
 	"github.com/nais/tobac/pkg/azure"
 )
@@ -13,14 +12,19 @@ import (
 func TestAzure(t *testing.T) {
 	ctx, _ := azure.DefaultContext(1 * time.Second)
 
+	t.Logf("Running live integration test to get teams from Azure AD")
+
 	teams, err := azure.Teams(ctx)
 	if err != nil {
-		fmt.Printf("%s", err)
+		t.Errorf("Azure AD returned error: %s", err)
+		t.FailNow()
 	}
 
+	t.Logf("Azure AD returned successfully with %d teams", len(teams))
+
+	n := 0
 	for _, team := range teams {
-		fmt.Printf("%+v\n", team)
+		n++
+		t.Logf("[%03d]: %+v\n", n, team)
 	}
-
-	assert.NoError(t, err)
 }

--- a/pkg/azure/graphapi.go
+++ b/pkg/azure/graphapi.go
@@ -1,0 +1,118 @@
+package azure
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+)
+
+// see https://docs.microsoft.com/en-us/graph/extensibility-schema-groups
+
+// List members
+// https://docs.microsoft.com/en-us/graph/api/group-list-members?view=graph-rest-1.0&tabs=http
+
+// With Azure AD resources that derive from directoryObject, like user and group,
+// $expand is only supported for beta and typically returns a maximum of 20 items for the expanded relationship.
+
+type GraphAPI struct {
+	client *http.Client
+}
+
+type DirectoryObject struct {
+	ID string `json:"id"`
+}
+
+type DirectoryObjectList struct {
+	Value []DirectoryObject `json:"value"`
+}
+
+type Group struct {
+	ID           string `json:"id"`
+	DisplayName  string `json:"displayName"`
+	MailNickname string `json:"mailNickname"`
+}
+
+type GroupList struct {
+	Value []Group
+}
+
+func NewGraphAPI(client *http.Client) *GraphAPI {
+	return &GraphAPI{
+		client: client,
+	}
+}
+
+func (g *GraphAPI) GroupsInGroup(groupID string) ([]Group, error) {
+	directoryObjects, err := g.directoryObjectsInGroup(groupID)
+	if err != nil {
+		return nil, fmt.Errorf("get parent group: %s", err)
+	}
+
+	groups := make([]Group, len(directoryObjects))
+	for i, directoryObject := range directoryObjects {
+		group, err := g.group(directoryObject.ID)
+		if err != nil {
+			return nil, fmt.Errorf("recurse into groups: %s", err)
+		}
+		groups[i] = *group
+	}
+
+	return groups, nil
+}
+
+func (g *GraphAPI) directoryObjectsInGroup(groupID string) ([]DirectoryObject, error) {
+	u := fmt.Sprintf("https://graph.microsoft.com/v1.0/groups/%s/members", groupID)
+	_, body, err := g.query(u, url.Values{})
+	if err != nil {
+		return nil, err
+	}
+
+	directoryObjectList := &DirectoryObjectList{}
+	err = json.Unmarshal(body, directoryObjectList)
+	if err != nil {
+		return nil, err
+	}
+
+	return directoryObjectList.Value, nil
+}
+func (g *GraphAPI) group(groupID string) (*Group, error) {
+	u := fmt.Sprintf("https://graph.microsoft.com/v1.0/groups/%s", groupID)
+
+	queryParams := url.Values{}
+	queryParams.Set("$select", "id,displayName,mailNickname")
+
+	group := &Group{}
+	_, body, err := g.query(u, queryParams)
+	if err != nil {
+		return nil, err
+	}
+
+	err = json.Unmarshal(body, group)
+	if err != nil {
+		return nil, err
+	}
+
+	return group, nil
+}
+
+func (g *GraphAPI) query(url string, queryParams url.Values) (response *http.Response, body []byte, err error) {
+	urlWithParams := url + "?" + queryParams.Encode()
+
+	response, err = g.client.Get(urlWithParams)
+	if err != nil {
+		return
+	}
+
+	body, err = ioutil.ReadAll(response.Body)
+	if err != nil {
+		return
+	}
+
+	if response.StatusCode > 299 {
+		err = fmt.Errorf("%s: %s", response.Status, string(body))
+	}
+
+	return
+}

--- a/pkg/azure/graphapi.go
+++ b/pkg/azure/graphapi.go
@@ -8,24 +8,18 @@ import (
 	"net/url"
 )
 
-// see https://docs.microsoft.com/en-us/graph/extensibility-schema-groups
-
-// List members
-// https://docs.microsoft.com/en-us/graph/api/group-list-members?view=graph-rest-1.0&tabs=http
-
-// With Azure AD resources that derive from directoryObject, like user and group,
-// $expand is only supported for beta and typically returns a maximum of 20 items for the expanded relationship.
-
 type GraphAPI struct {
 	client *http.Client
 }
 
-type DirectoryObject struct {
-	ID string `json:"id"`
+type ServicePrincipal struct {
+	PrincipalID   string `json:"principalId"`
+	PrincipalType string `json:"principalType"`
 }
 
-type DirectoryObjectList struct {
-	Value []DirectoryObject `json:"value"`
+type ServicePrincipalList struct {
+	NextLink string             `json:"@odata.nextLink"`
+	Value    []ServicePrincipal `json:"value"`
 }
 
 type Group struct {
@@ -44,39 +38,55 @@ func NewGraphAPI(client *http.Client) *GraphAPI {
 	}
 }
 
-func (g *GraphAPI) GroupsInGroup(groupID string) ([]Group, error) {
-	directoryObjects, err := g.directoryObjectsInGroup(groupID)
+// Retrieve a list of Azure Groups that are given access to a specific Azure Application.
+func (g *GraphAPI) GroupsFromApplication(appID string) ([]Group, error) {
+	servicePrincipals, err := g.servicePrincipalsInApplication(appID)
 	if err != nil {
 		return nil, fmt.Errorf("get parent group: %s", err)
 	}
 
-	groups := make([]Group, len(directoryObjects))
-	for i, directoryObject := range directoryObjects {
-		group, err := g.group(directoryObject.ID)
+	groups := make([]Group, 0)
+	for _, servicePrincipal := range servicePrincipals {
+		if servicePrincipal.PrincipalType != "Group" {
+			continue
+		}
+		group, err := g.group(servicePrincipal.PrincipalID)
 		if err != nil {
 			return nil, fmt.Errorf("recurse into groups: %s", err)
 		}
-		groups[i] = *group
+		groups = append(groups, *group)
 	}
 
 	return groups, nil
 }
 
-func (g *GraphAPI) directoryObjectsInGroup(groupID string) ([]DirectoryObject, error) {
-	u := fmt.Sprintf("https://graph.microsoft.com/v1.0/groups/%s/members", groupID)
-	_, body, err := g.query(u, url.Values{})
-	if err != nil {
-		return nil, err
+// https://docs.microsoft.com/en-us/graph/api/approleassignment-get?view=graph-rest-beta&tabs=http
+func (g *GraphAPI) servicePrincipalsInApplication(appID string) ([]ServicePrincipal, error) {
+	servicePrincipals := make([]ServicePrincipal, 0)
+
+	queryParams := url.Values{}
+	queryParams.Set("$top", "999")
+	queryParams.Set("$select", "principalId,principalType")
+	nextURL := fmt.Sprintf("https://graph.microsoft.com/beta/servicePrincipals/%s/appRoleAssignments?%s", appID, queryParams.Encode())
+
+	for len(nextURL) != 0 {
+		_, body, err := g.query(nextURL)
+		if err != nil {
+			return nil, err
+		}
+
+		servicePrincipalList := &ServicePrincipalList{}
+		err = json.Unmarshal(body, servicePrincipalList)
+		if err != nil {
+			return nil, err
+		}
+		servicePrincipals = append(servicePrincipals, servicePrincipalList.Value...)
+		nextURL = servicePrincipalList.NextLink
 	}
 
-	directoryObjectList := &DirectoryObjectList{}
-	err = json.Unmarshal(body, directoryObjectList)
-	if err != nil {
-		return nil, err
-	}
-
-	return directoryObjectList.Value, nil
+	return servicePrincipals, nil
 }
+
 func (g *GraphAPI) group(groupID string) (*Group, error) {
 	u := fmt.Sprintf("https://graph.microsoft.com/v1.0/groups/%s", groupID)
 
@@ -84,7 +94,7 @@ func (g *GraphAPI) group(groupID string) (*Group, error) {
 	queryParams.Set("$select", "id,displayName,mailNickname")
 
 	group := &Group{}
-	_, body, err := g.query(u, queryParams)
+	_, body, err := g.query(u + "?" + queryParams.Encode())
 	if err != nil {
 		return nil, err
 	}
@@ -97,10 +107,8 @@ func (g *GraphAPI) group(groupID string) (*Group, error) {
 	return group, nil
 }
 
-func (g *GraphAPI) query(url string, queryParams url.Values) (response *http.Response, body []byte, err error) {
-	urlWithParams := url + "?" + queryParams.Encode()
-
-	response, err = g.client.Get(urlWithParams)
+func (g *GraphAPI) query(url string) (response *http.Response, body []byte, err error) {
+	response, err = g.client.Get(url)
 	if err != nil {
 		return
 	}

--- a/pkg/azure/graphapi.go
+++ b/pkg/azure/graphapi.go
@@ -67,7 +67,7 @@ func (g *GraphAPI) servicePrincipalsInApplication(appID string) ([]ServicePrinci
 	queryParams := url.Values{}
 	queryParams.Set("$top", "999")
 	queryParams.Set("$select", "principalId,principalType")
-	nextURL := fmt.Sprintf("https://graph.microsoft.com/beta/servicePrincipals/%s/appRoleAssignments?%s", appID, queryParams.Encode())
+	nextURL := fmt.Sprintf("https://graph.microsoft.com/beta/servicePrincipals/%s/appRoleAssignedTo?%s", appID, queryParams.Encode())
 
 	for len(nextURL) != 0 {
 		_, body, err := g.query(nextURL)

--- a/pkg/teams/teams.go
+++ b/pkg/teams/teams.go
@@ -1,6 +1,7 @@
 package teams
 
 import (
+	"strings"
 	"sync"
 	"time"
 
@@ -41,6 +42,7 @@ func Sync(interval, timeout time.Duration) {
 
 // Get returns a team with the specified identified
 func Get(id string) azure.Team {
+	id = strings.ToLower(id)
 	mutex.Lock()
 	defer mutex.Unlock()
 	return teamList[id]


### PR DESCRIPTION
This PR changes the master source of teams from the SharePoint table to _App Role Assignments_ belonging to a specific Azure AD application.

Merging requires a new environment variable `AZURE_TEAM_MEMBERSHIP_APP_ID` that points to an application that is provisioned by the https://github.com/navikt/teams repository.